### PR TITLE
Fixing typos in the examples

### DIFF
--- a/R/get_pto.r
+++ b/R/get_pto.r
@@ -14,9 +14,9 @@
 #' \dontrun{
 #' user <- 'your_api_user'
 #' password <- 'your_password'
-+#' startDate = lubridate::ymd("20190101")
-+#' endDate = lubridate::ymd("20191231")
-+#' employees <- get_pto(user = user, password = password, startDate = startDate, endDate = endDate)
+#' startDate = lubridate::ymd("20190101")
+#' endDate = lubridate::ymd("20191231")
+#' employees <- get_pto(user = user, password = password, startDate = startDate, endDate = endDate)
 #'}
 #'
 #' @author Mark Druffel, \email{mdruffel@propellerpdx.com}

--- a/man/get_pto.Rd
+++ b/man/get_pto.Rd
@@ -30,7 +30,9 @@ Submits a get request to retrieve the all employees time off by date
 \dontrun{
 user <- 'your_api_user'
 password <- 'your_password'
-employees <- get_pto(user=user,password=password)
+startDate = lubridate::ymd("20190101")
+endDate = lubridate::ymd("20191231")
+employees <- get_pto(user = user, password = password, startDate = startDate, endDate = endDate)
 }
 
 }


### PR DESCRIPTION
New examples were breaking bambooR 'cause of a typo I missed in the GitHub file browser